### PR TITLE
Surface branch flag by including it in tree

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -22,6 +22,7 @@ function parallel() {
     tree: {
       label: fn.displayName,
       type: 'function',
+      branch: true,
       nodes: buildTree(args),
     },
   });

--- a/lib/series.js
+++ b/lib/series.js
@@ -22,6 +22,7 @@ function series() {
     tree: {
       label: fn.displayName,
       type: 'function',
+      branch: true,
       nodes: buildTree(args),
     },
   });

--- a/test/fixtures/taskTree/aliasNested.js
+++ b/test/fixtures/taskTree/aliasNested.js
@@ -30,6 +30,7 @@ module.exports = {
         {
           label: '<series>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: 'noop',
@@ -67,6 +68,7 @@ module.exports = {
         {
           label: '<parallel>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: 'noop',

--- a/test/fixtures/taskTree/doubleLevel.js
+++ b/test/fixtures/taskTree/doubleLevel.js
@@ -20,6 +20,7 @@ module.exports = {
         {
           label: '<series>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: 'fn1',

--- a/test/fixtures/taskTree/tripleLevel.js
+++ b/test/fixtures/taskTree/tripleLevel.js
@@ -10,6 +10,7 @@ module.exports = {
         {
           label: '<parallel>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: '<anonymous>',
@@ -32,6 +33,7 @@ module.exports = {
         {
           label: '<parallel>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: '<anonymous>',
@@ -54,6 +56,7 @@ module.exports = {
         {
           label: '<series>',
           type: 'function',
+          branch: true,
           nodes: [
             {
               label: 'fn1',
@@ -62,6 +65,7 @@ module.exports = {
                 {
                   label: '<parallel>',
                   type: 'function',
+                  branch: true,
                   nodes: [
                     {
                       label: '<anonymous>',
@@ -84,6 +88,7 @@ module.exports = {
                 {
                   label: '<parallel>',
                   type: 'function',
+                  branch: true,
                   nodes: [
                     {
                       label: '<anonymous>',


### PR DESCRIPTION
I've added a branch property of each series/parallel task in its tree property. By this, outside programs including gulp-cli can distinguish series/parallel tasks from other tasks in a task tree.