### PR TITLE
series/parallel arguments cannot be objects, and cannot be empty arrays, and corrected previous test in parallel.js

### DIFF
--- a/lib/helpers/normalizeArgs.js
+++ b/lib/helpers/normalizeArgs.js
@@ -17,7 +17,7 @@ function normalizeArgs(registry, args) {
     return fn;
   }
 
-  assert(flatten(args).length !== 0, 'Empty array as argument');
+  assert(flatten(args).length, 'Empty array as argument or no argument');
   return map(flatten(args), getFunction);
 }
 

--- a/lib/helpers/normalizeArgs.js
+++ b/lib/helpers/normalizeArgs.js
@@ -12,10 +12,12 @@ function normalizeArgs(registry, args) {
     }
 
     var fn = registry.get(task);
+
     assert(fn, 'Task never defined: ' + task);
     return fn;
   }
 
+  assert(flatten(args).length !== 0, 'Empty array as argument');
   return map(flatten(args), getFunction);
 }
 

--- a/lib/series.js
+++ b/lib/series.js
@@ -10,7 +10,9 @@ var createExtensions = require('./helpers/createExtensions');
 function series() {
   var create = this._settle ? bach.settleSeries : bach.series;
 
+
   var args = normalizeArgs(this._registry, arguments);
+
   var extensions = createExtensions(this);
   var fn = create(args, extensions);
 

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -34,6 +34,24 @@ describe('parallel', function() {
     done();
   });
 
+  it('should not take an empty array', function(done) {
+    function emptyArray() {
+      taker.parallel([]);
+    }
+
+    expect(emptyArray).toThrow('Empty array as argument');
+    done();
+  });
+
+  it('should not take objects', function(done) {
+    function objectAsArgument() {
+      taker.parallel(['test1',{}]);
+    }
+
+    expect(objectAsArgument).toThrow('Task never defined:');
+    done();
+  });
+
   it('should take only one array of registered tasks', function(done) {
     taker.parallel(['test1', 'test2', 'test3'])(function(err, results) {
       expect(results).toEqual([1, 2, 3]);

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -34,12 +34,21 @@ describe('parallel', function() {
     done();
   });
 
+  it('should not take an empty argument', function(done) {
+    function emptyArgument() {
+      taker.parallel();
+    }
+
+    expect(emptyArgument).toThrow('Empty array as argument or no argument');
+    done();
+  });
+
   it('should not take an empty array', function(done) {
     function emptyArray() {
       taker.parallel([]);
     }
 
-    expect(emptyArray).toThrow('Empty array as argument');
+    expect(emptyArray).toThrow('Empty array as argument or no argument');
     done();
   });
 

--- a/test/series.js
+++ b/test/series.js
@@ -34,12 +34,21 @@ describe('series', function() {
     done();
   });
 
+  it('should not take an empty argument', function(done) {
+    function emptyArgument() {
+      taker.series();
+    }
+
+    expect(emptyArgument).toThrow('Empty array as argument or no argument');
+    done();
+  });
+
   it('should not take an empty array', function(done) {
     function emptyArray() {
       taker.series([]);
     }
 
-    expect(emptyArray).toThrow('Empty array as argument');
+    expect(emptyArray).toThrow('Empty array as argument or no argument');
     done();
   });
 

--- a/test/series.js
+++ b/test/series.js
@@ -34,6 +34,24 @@ describe('series', function() {
     done();
   });
 
+  it('should not take an empty array', function(done) {
+    function emptyArray() {
+      taker.series([]);
+    }
+
+    expect(emptyArray).toThrow('Empty array as argument');
+    done();
+  });
+
+  it('should not take objects', function(done) {
+    function objectAsArgument() {
+      taker.series(['test1',{}]);
+    }
+
+    expect(objectAsArgument).toThrow('Task never defined:');
+    done();
+  });
+
   it('should take only one array of registered tasks', function(done) {
     taker.series(['test1', 'test2', 'test3'])(function(err, results) {
       expect(results).toEqual([1, 2, 3]);


### PR DESCRIPTION
Fixes issue https://github.com/gulpjs/undertaker/issues/72