### PR TITLE
Added new assert error on task execution chain

### DIFF
--- a/lib/set-task.js
+++ b/lib/set-task.js
@@ -8,7 +8,7 @@ function set(name, fn) {
   assert(name, 'Task name must be specified');
   assert(typeof name === 'string', 'Task name must be a string');
   if (typeof fn === 'object') {
-    assert.fail('Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/');
+    assert.fail('Wrong Concatenetion! Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/');
   }
   assert(typeof fn === 'function', 'Task function must be specified');
 

--- a/lib/set-task.js
+++ b/lib/set-task.js
@@ -8,7 +8,7 @@ function set(name, fn) {
   assert(name, 'Task name must be specified');
   assert(typeof name === 'string', 'Task name must be a string');
   if (typeof fn === 'object') {
-    assert.fail('Wrong Concatenetion! Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/');
+    assert.fail('Wrong Concatenation! Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/');
   }
   assert(typeof fn === 'function', 'Task function must be specified');
 

--- a/lib/set-task.js
+++ b/lib/set-task.js
@@ -7,6 +7,9 @@ var metadata = require('./helpers/metadata');
 function set(name, fn) {
   assert(name, 'Task name must be specified');
   assert(typeof name === 'string', 'Task name must be a string');
+  if (typeof fn === 'object') {
+    assert.fail('Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/');
+  }
   assert(typeof fn === 'function', 'Task function must be specified');
 
   function taskWrapper() {


### PR DESCRIPTION
When you use old task execution system now it throws an error.... Before it was totally vague.
## Example
```javascript
var Undertaker = require('./index');

var taker = new Undertaker();

taker.task('task1', function(cb){
  // do things

  cb(); // when everything is done
});

taker.task('task2', function(){
  return fs.createReadStream('./myFile.js')
    .pipe(fs.createWriteStream('./myFile.copy.js'));
});

taker.task('combined', ['task1', 'task2']);
```
## Before:
```javascript
assert.js:42
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Task function must be specified
    at Undertaker.set [as _setTask] (C:\Users\danie\Google Drive\Projects WebSites\undertaker\lib\set-task.js:11:3)
    at Undertaker.task (C:\Users\danie\Google Drive\Projects WebSites\undertaker\lib\task.js:13:8)
    at Object.<anonymous> (C:\Users\danie\Google Drive\Projects WebSites\undertaker\example.js:16:7)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
    at startup (bootstrap_node.js:190:16)
```

## Now:
```javascript
assert.js:42
  throw new errors.AssertionError({
  ^

AssertionError [ERR_ASSERTION]: Wrong Concatenetion! Check out the new task execution system: https://fettblog.eu/gulp-4-parallel-and-series/
    at Undertaker.set [as _setTask] (C:\Users\danie\Google Drive\Projects WebSites\undertaker\lib\set-task.js:11:12)
    at Undertaker.task (C:\Users\danie\Google Drive\Projects WebSites\undertaker\lib\task.js:13:8)
    at Object.<anonymous> (C:\Users\danie\Google Drive\Projects WebSites\undertaker\example.js:17:7)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
    at startup (bootstrap_node.js:190:16)
```
