### PR TITLE
Fix: Improve error messages when resolving tasks

### DIFF
--- a/lib/set-task.js
+++ b/lib/set-task.js
@@ -6,8 +6,10 @@ var metadata = require('./helpers/metadata');
 
 function set(name, fn) {
   assert(name, 'Task name must be specified');
-  assert(typeof name === 'string', 'Task name must be a string');
-  assert(typeof fn === 'function', 'Task function must be specified');
+  assert(typeof name === 'string', 'Task name must be a string, ' +
+    'instead got "' + name + '"');
+  assert(typeof fn === 'function', 'Task function must be specified ' +
+    'for "' + name + '", instead got "' + fn + '"');
 
   function taskWrapper() {
     return fn.apply(this, arguments);

--- a/test/set-task.js
+++ b/test/set-task.js
@@ -1,0 +1,21 @@
+var expect = require('expect');
+
+var Undertaker = require('../');
+
+describe('set-task', function() {
+  var taker;
+
+  beforeEach(function(done) {
+    taker = new Undertaker();
+    done();
+  });
+
+  it('should check preconditions', function(done) {
+    expect(function() {
+      taker._setTask('v4task', ['v3task1', 'v3task2']);
+    }).toThrow('Task function must be specified for "v4task"' +
+      ', instead got "v3task1,v3task2"');
+
+    done();
+  });
+});


### PR DESCRIPTION
When updating from gulp 3 to 4, this function is the first one to
fail when the file contains the old exec chain:

```
gulp.task('task', ['task2', 'task3'], function() {...});
```

Prior this commit, the error message is too cryptic. This commit fixes
that by specifying in the message, the actual argument it got during
precondition.