### PR TITLE
Fix: Do not set displayName.

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -13,14 +13,13 @@ function parallel() {
   var args = normalizeArgs(this._registry, arguments);
   var extensions = createExtensions(this);
   var fn = create(args, extensions);
-
-  fn.displayName = '<parallel>';
+  var name = '<parallel>';
 
   metadata.set(fn, {
-    name: fn.displayName,
+    name: name,
     branch: true,
     tree: {
-      label: fn.displayName,
+      label: name,
       type: 'function',
       branch: true,
       nodes: buildTree(args),

--- a/lib/series.js
+++ b/lib/series.js
@@ -13,14 +13,13 @@ function series() {
   var args = normalizeArgs(this._registry, arguments);
   var extensions = createExtensions(this);
   var fn = create(args, extensions);
-
-  fn.displayName = '<series>';
+  var name = '<series>';
 
   metadata.set(fn, {
-    name: fn.displayName,
+    name: name,
     branch: true,
     tree: {
-      label: fn.displayName,
+      label: name,
       type: 'function',
       branch: true,
       nodes: buildTree(args),

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -146,4 +146,10 @@ describe('parallel', function() {
       done();
     });
   });
+
+  it('should not register a displayName on the returned function by default', function(done) {
+    var task = taker.parallel(fn1);
+    expect(task.displayName).toEqual(undefined);
+    done();
+  });
 });

--- a/test/series.js
+++ b/test/series.js
@@ -147,4 +147,9 @@ describe('series', function() {
     });
   });
 
+  it('should not register a displayName on the returned function by default', function(done) {
+    var task = taker.series(fn1);
+    expect(task.displayName).toEqual(undefined);
+    done();
+  });
 });


### PR DESCRIPTION
This will allow `gulp-cli` to preferentially use displayName to
calculate the name of the task.  Previously when displayName was set in
series and parallel this caused tasks declared with exports to have the
wrong name.  I've removed setting of displayName from set-task.js for
consistency, this is not required for the fix.