### PR TITLE
chore!: Stop inspecting UNDERTAKER_TIME_RESOLUTION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,12 @@ should probably be re-run from scratch to get into a good state again.
 
 The timestamp is always given in millisecond but the time resolution can be
 rounded using the `precision` parameter. The use case is to be able to compare a build time
-to a file time attribute. On node v0.10 or with file system like HFS or FAT,
-`fs.stat` time attributes like `mtime` precision is one second.
+to a file time attribute.
 
 Assuming `undertakerInst.lastRun('someTask')` returns `1426000001111`,
 `undertakerInst.lastRun('someTask', 1000)` returns `1426000001000`.
 
-The default time resolution is `1000` on node v0.10, `0` on node 0.11+ but
-it can be overwritten using `UNDERTAKER_TIME_RESOLUTION` environment variable.
+The default time resolution is `1`.
 
 ## Custom Registries
 

--- a/lib/last-run.js
+++ b/lib/last-run.js
@@ -5,10 +5,6 @@ var retrieveLastRun = require('last-run');
 var metadata = require('./helpers/metadata');
 
 function lastRun(task, timeResolution) {
-  if (timeResolution == null) {
-    timeResolution = process.env.UNDERTAKER_TIME_RESOLUTION;
-  }
-
   var fn = task;
   if (typeof task === 'string') {
     fn = this._getTask(task);


### PR DESCRIPTION
(This PR is based on `chore-normalize-repository` branch for #97.)

I looked into that what other modules use `UNDERTAKER_TIME_RESOLUTION`, but no module uses. So this PR removes the codes and docs about the environment variable in this package.

Closes #92 