### PR TITLE
feat: Attach properties to missing task error

### DIFF
--- a/lib/helpers/normalizeArgs.js
+++ b/lib/helpers/normalizeArgs.js
@@ -13,11 +13,16 @@ function normalizeArgs(registry, args) {
     var fn = registry.get(task);
     if (!fn) {
       var similar = similarTasks(registry, task);
+      var err;
       if (similar.length > 0) {
-        assert(false, 'Task never defined: ' + task + ' - did you mean? ' + similar.join(', '));
+        err = new Error('Task never defined: ' + task + ' - did you mean? ' + similar.join(', '));
+        err.task = task;
+        err.similar = similar;
       } else {
-        assert(false, 'Task never defined: ' + task);
+        err = new Error('Task never defined: ' + task);
+        err.task = task;
       }
+      throw err;
     }
     return fn;
   }


### PR DESCRIPTION
@sttk Please review. We can normalize the gulp 4 error with your changes in gulp-cli following these same properties.